### PR TITLE
new-humanitec-app-onboarding

### DIFF
--- a/node-service/template.yaml
+++ b/node-service/template.yaml
@@ -2,7 +2,7 @@ apiVersion: scaffolder.backstage.io/v1beta3
 kind: Template
 metadata:
   name: nodejs-service-template
-  title: NodeJS Service Template
+  title: NodeJS Service + PostgreSQL Template
   description: An example template that creates a simple NodeJS service talking to a PostgreSQL database
   tags:
     - score
@@ -43,8 +43,18 @@ spec:
           cloudProvider: ${{ steps.environment.output.cloudProvider }}
           githubOrgId: ${{ steps.environment.output.githubOrgId }}
 
-    - id: publish
-      name: Publish
+    - id: trigger-pipeline
+      name: Onboard Humanitec App
+      action: github:actions:dispatch
+      input:
+        repoUrl: 'github.com?repo=backstage&owner=${{ steps.environment.output.githubOrgId }}'
+        workflowId: 'onboard-humanitec-app.yaml'
+        branchOrTagName: 'main'
+        workflowInputs:
+          app_id: ${{ parameters.componentName }}
+
+    - id: create-repo
+      name: Create GitHub repository
       action: publish:github
       input:
         allowedHosts: ['github.com']
@@ -55,14 +65,8 @@ spec:
         protectDefaultBranch: false
         oidcCustomization: ${{ steps.environment.output.githubOIDCCustomization }}
 
-    - id: humanitec-create-app
-      name: Create Humanitec App
-      action: humanitec:create-app
-      input:
-        appId: ${{ parameters.componentName }}
-
     - id: register
-      name: Register
+      name: Register Component in Catalog
       action: catalog:register
       input:
         repoContentsUrl: ${{ steps['publish'].output.repoContentsUrl }}

--- a/node-service/template.yaml
+++ b/node-service/template.yaml
@@ -69,13 +69,13 @@ spec:
       name: Register Component in Catalog
       action: catalog:register
       input:
-        repoContentsUrl: ${{ steps['publish'].output.repoContentsUrl }}
+        repoContentsUrl: ${{ steps['create-repo'].output.repoContentsUrl }}
         catalogInfoPath: '/catalog-info.yaml'
 
   output:
     links:
       - title: Repository
-        url: ${{ steps['publish'].output.remoteUrl }}
+        url: ${{ steps['create-repo'].output.remoteUrl }}
       - title: Open in catalog
         icon: catalog
         entityRef: ${{ steps['register'].output.entityRef }}

--- a/podinfo/template.yaml
+++ b/podinfo/template.yaml
@@ -42,6 +42,16 @@ spec:
           cloudProvider: ${{ steps.environment.output.cloudProvider }}
           githubOrgId: ${{ steps.environment.output.githubOrgId }}
 
+    - id: trigger-pipeline
+      name: Onboard Humanitec App Onboarding
+      action: github:actions:dispatch
+      input:
+        repoUrl: 'github.com?repo=backstage&owner=${{ steps.environment.output.githubOrgId }}'
+        workflowId: 'onboard-humanitec-app.yaml'
+        branchOrTagName: 'main'
+        workflowInputs:
+          app_id: ${{ parameters.componentName }}
+    
     - id: publish
       name: Publish
       action: publish:github
@@ -53,12 +63,6 @@ spec:
         repoVisibility: public
         protectDefaultBranch: false
         oidcCustomization: ${{ steps.environment.output.githubOIDCCustomization }}
-
-    - id: humanitec-create-app
-      name: Create Humanitec App
-      action: humanitec:create-app
-      input:
-        appId: ${{ parameters.componentName }}
 
     - id: register
       name: Register

--- a/podinfo/template.yaml
+++ b/podinfo/template.yaml
@@ -52,8 +52,8 @@ spec:
         workflowInputs:
           app_id: ${{ parameters.componentName }}
     
-    - id: publish
-      name: Publish
+    - id: create-repo
+      name: Create GitHub repository
       action: publish:github
       input:
         allowedHosts: ['github.com']
@@ -65,7 +65,7 @@ spec:
         oidcCustomization: ${{ steps.environment.output.githubOIDCCustomization }}
 
     - id: register
-      name: Register
+      name: Register Component in Catalog
       action: catalog:register
       input:
         repoContentsUrl: ${{ steps['publish'].output.repoContentsUrl }}

--- a/podinfo/template.yaml
+++ b/podinfo/template.yaml
@@ -65,16 +65,16 @@ spec:
         oidcCustomization: ${{ steps.environment.output.githubOIDCCustomization }}
 
     - id: register
-      name: Register
+      name: Register Component in Catalog
       action: catalog:register
       input:
-        repoContentsUrl: ${{ steps['publish'].output.repoContentsUrl }}
+        repoContentsUrl: ${{ steps['create-repo'].output.repoContentsUrl }}
         catalogInfoPath: '/catalog-info.yaml'
 
   output:
     links:
       - title: Repository
-        url: ${{ steps['publish'].output.remoteUrl }}
+        url: ${{ steps['create-repo'].output.remoteUrl }}
       - title: Open in catalog
         icon: catalog
         entityRef: ${{ steps['register'].output.entityRef }}

--- a/podinfo/template.yaml
+++ b/podinfo/template.yaml
@@ -65,7 +65,7 @@ spec:
         oidcCustomization: ${{ steps.environment.output.githubOIDCCustomization }}
 
     - id: register
-      name: Register Component in Catalog
+      name: Register
       action: catalog:register
       input:
         repoContentsUrl: ${{ steps['publish'].output.repoContentsUrl }}

--- a/podinfo/template.yaml
+++ b/podinfo/template.yaml
@@ -43,7 +43,7 @@ spec:
           githubOrgId: ${{ steps.environment.output.githubOrgId }}
 
     - id: trigger-pipeline
-      name: Onboard Humanitec App Onboarding
+      name: Onboard Humanitec App
       action: github:actions:dispatch
       input:
         repoUrl: 'github.com?repo=backstage&owner=${{ steps.environment.output.githubOrgId }}'


### PR DESCRIPTION
From Backstage, we now on trigger a GitHub Actions that will actually do the Humanitec App onboarding. This GHA could execute a bash script with `humctl` or `terraform`.

The idea is that just creating an App in Humanitec is not enough, it requires more objects in Humanitec: `config`, `environments`, `service users`, etc.

This needs to add the ["Repository permissions for "Actions"](https://docs.github.com/en/rest/authentication/permissions-required-for-github-apps?apiVersion=2022-11-28#repository-permissions-for-actions) on the GitHub App installed for Backstage. For that, you'll need to make sure you have installed the latest GH App with this update: https://github.com/humanitec-architecture/create-gh-app/pull/1.

Other resources:
- https://docs.github.com/en/rest/actions/workflows?apiVersion=2022-11-28#create-a-workflow-dispatch-event
- https://github.com/backstage/backstage/tree/master/plugins/scaffolder-backend-module-github