### PR TITLE
Use `mirror.gcr.io/` to avoid DockerHub rate limits error while using these Backstage samples

### DIFF
--- a/5min-node-service/content/Dockerfile
+++ b/5min-node-service/content/Dockerfile
@@ -1,9 +1,9 @@
-FROM alpine:3 as builder
+FROM mirror.gcr.io/alpine:3 as builder
 RUN apk add --no-cache nodejs npm
 COPY package*.json ./
 RUN npm install --only=prod
 
-FROM alpine:3
+FROM mirror.gcr.io/alpine:3
 RUN apk add --no-cache nodejs
 COPY --from=builder /node_modules ./node_modules
 COPY index.js index.js

--- a/5min-podinfo/content/Dockerfile
+++ b/5min-podinfo/content/Dockerfile
@@ -1,1 +1,1 @@
-FROM stefanprodan/podinfo:latest
+FROM ghcr.io/stefanprodan/podinfo:latest

--- a/node-service/content/Dockerfile
+++ b/node-service/content/Dockerfile
@@ -1,9 +1,9 @@
-FROM alpine:3 as builder
+FROM mirror.gcr.io/alpine:3 as builder
 RUN apk add --no-cache nodejs npm
 COPY package*.json ./
 RUN npm install --only=prod
 
-FROM alpine:3
+FROM mirror.gcr.io/alpine:3
 RUN apk add --no-cache nodejs
 COPY --from=builder /node_modules ./node_modules
 COPY index.js index.js

--- a/podinfo/content/Dockerfile
+++ b/podinfo/content/Dockerfile
@@ -1,1 +1,1 @@
-FROM stefanprodan/podinfo:latest
+FROM ghcr.io/stefanprodan/podinfo:latest


### PR DESCRIPTION
Use `mirror.gcr.io/` to avoid DockerHub rate limits error while using these Backstage samples:
- https://docs.docker.com/docker-hub/usage/
- https://cloud.google.com/artifact-registry/docs/pull-cached-dockerhub-images
- https://devtron.ai/blog/dodging-docker-hub-rate-limits-the-ultimate-cheat-code-for-your-ci-cd-pipeline/

> Starting April 1, 2025, all users with a Pro, Team, or Business subscription will have unlimited Docker Hub pulls with fair use. Unauthenticated users and users with a free Personal account have the following pull limits:
> - Unauthenticated users: 10 pulls/hour
> - Authenticated users with a free account: 100 pulls/hour


Also, using `ghcr.io/stefanprodan/podinfo`.